### PR TITLE
Support for fetching formula directly from the project repo

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -87,6 +87,7 @@ pub fn clone(url: &str, dest: &Path, options: CloneOption) -> Result<(), Report>
     }
 
     let mut child = match ChildProcess::new("git")
+        .stderr(Stdio::null())
         .arg("clone")
         .arg(url)
         .args(args)
@@ -112,14 +113,6 @@ pub fn clone(url: &str, dest: &Path, options: CloneOption) -> Result<(), Report>
 
     if exit_code == 0 {
         return Ok(());
-    }
-
-    if exit_code == 128 {
-        eprintln!("It looks like the package does not support Cask");
-        eprintln!(
-            "If you are the package owner, try to create a new repository '{}' and add a Cask.toml file",
-            url
-        )
     }
 
     Err(eyre::format_err!(


### PR DESCRIPTION
close #4

I didn't use the method of determining if the repo exists first, since we are supporting two repo scenarios, there may be a repo in `{package}-cask` format but it is not used to store the `Cask.toml` file, this patch uses a simpler method and supports more scenarios, see my test results for https://github.com/iawia002/casktest-cask repo:

```
Fetching github.com/iawia002/casktest formula...
Downloading https://github.com/iawia002/lux/releases/download/v0.14.0/lux_0.14.0_macOS_64-bit.tar.gz
  [00:00:04] [###############################################################################################################################################################################################################] 13.79MiB/13.79MiB (3.41MiB/s, 0s)
The package 'github.com/iawia002/lux 0.14.0' has been installed!
Try run the command 'lux --help' to make sure it works!
```

Repo non-existent test:

```
Fetching github.com/iawia002/casktest1 formula...
It looks like the package does not support Cask
If you are the package owner, see our documentation for how to publish a package: https://github.com/axetroy/cask.rs/blob/main/DESIGN.md#how-do-i-publish-myothers-package
thread 'main' panicked at 'install package fail!: clone repository fail and exit code: 128
```

cc @axetroy I'll update the documentation if it's okay