### PR TITLE
refactor: remove unused check_exist function

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -14,48 +14,6 @@ pub struct CloneOption {
     pub filter: Option<String>,
 }
 
-// check remote repository exist or not
-pub fn check_exist(url: &str) -> Result<bool, Report> {
-    let mut child = match ChildProcess::new("git")
-        .arg("ls-remote")
-        .arg("-h")
-        .arg(url)
-        .stderr(Stdio::null())
-        .stdout(Stdio::null())
-        .env("GIT_TERMINAL_PROMPT", "0")
-        .spawn()
-    {
-        Ok(child) => Ok(child),
-        Err(e) => Err(eyre::format_err!("{}", e)),
-    }?;
-
-    let timeout = Duration::from_secs(30);
-
-    let state = match child.wait_timeout(timeout)? {
-        Some(status) => status.code(),
-        None => {
-            // child hasn't exited yet
-            child.kill()?;
-            child.wait()?.code()
-        }
-    };
-
-    let exit_code = state.unwrap_or(1);
-
-    if exit_code == 0 {
-        return Ok(true);
-    }
-
-    if exit_code == 128 {
-        return Ok(false);
-    }
-
-    Err(eyre::format_err!(
-        "check repository fail and exit code: {}",
-        exit_code,
-    ))
-}
-
 // clone repository into dest dir
 pub fn clone(url: &str, dest: &Path, options: CloneOption) -> Result<(), Report> {
     let mut args: Vec<String> = vec![];
@@ -148,25 +106,5 @@ mod tests {
         assert!(dest_dir.exists());
 
         fs::remove_dir_all(dest_dir).unwrap();
-    }
-
-    #[test]
-    fn test_check_exist_if_exist() {
-        let url1 = "https://github.com/axetroy/gpm.rs.git";
-
-        let r1 = git::check_exist(url1);
-
-        assert!(r1.is_ok());
-        assert!(r1.unwrap());
-    }
-
-    #[test]
-    fn test_check_exist_if_not_exist() {
-        let url1 = "https://github.com/axetroy/not_exist.git";
-
-        let r1 = git::check_exist(url1);
-
-        assert!(r1.is_ok());
-        assert!(!r1.unwrap())
     }
 }


### PR DESCRIPTION
Since #9 used another way, we don't need this function anymore, this patch removes this function to avoid the blow warning:

```
warning: function is never used: `check_exist`
  --> src/git.rs:18:8
   |
18 | pub fn check_exist(url: &str) -> Result<bool, Report> {
   |        ^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: `cask` (bin "cask") generated 1 warning
```